### PR TITLE
Fix for libboost-python (Python 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,8 @@ if (BUILD_PYTHON)
   endif ()
 
   # boost-python
-  set (BOOST_PYTHON_COMPONENT_NAMES python${PYTHON_VERSION_MAJOR} python)
+  set (BOOST_PYTHON_COMPONENT_NAMES
+    python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} python)
   foreach (NAME ${BOOST_PYTHON_COMPONENT_NAMES})
     if (NOT Boost_FOUND)
       message (STATUS "Looking for component ${NAME}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,19 @@ if (BUILD_PYTHON)
 
   # python site dir
   if (PYTHON_EXECUTABLE AND NOT DEFINED PYTHON_SITE_DIR)
-    execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}'))"
+    # $ENV{VIRTUAL_ENV} does not work because not exported by activate :/
+    execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "
+import sys;
+if 'real_prefix' in dir(sys):
+    print(sys.prefix)"
+    # sys.real_prefix is only defined when in virtualenv
+      OUTPUT_VARIABLE SITE_DIR_PREFIX
+      RESULT_VARIABLE _exit_code
+      OUTPUT_STRIP_TRAILING_WHITESPACE )
+    if (${SITE_DIR_PREFIX}) # if not set, back to previous behaviour
+      set (SITE_DIR_PREFIX ${CMAKE_INSTALL_PREFIX})
+    endif ()
+    execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(plat_specific=True, prefix='${SITE_DIR_PREFIX}'))"
                          OUTPUT_VARIABLE _ABS_PYTHON_SITE_DIR
                          RESULT_VARIABLE _exit_code
                          OUTPUT_STRIP_TRAILING_WHITESPACE )


### PR DESCRIPTION
1. `import lcmaes` just fails with an explicit error with Python since CMake links Python 3 to the libboost-python compiled for Python 2...
2. if you compile from inside a virtual environment, the library is not installed at the proper location and the import fails
