### PR TITLE
Fix for optimization flags in Limbo library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,13 +58,9 @@ check_include_file (sys/types.h HAVE_SYS_TYPES_H)
 check_include_file (sys/stat.h HAVE_SYS_STAT_H)
 
 # eigen
-find_package (Eigen3 NO_MODULE)
-if (EIGEN3_FOUND)
-  include (${EIGEN3_USE_FILE})
-else ()
-  find_package (Eigen3 REQUIRED)
-  include_directories (${EIGEN3_INCLUDE_DIRS})
-endif()
+find_package (Eigen3 REQUIRED)
+include_directories (${EIGEN3_INCLUDE_DIRS})
+message(STATUS "Eigen3 found: ${EIGEN3_INCLUDE_DIRS}")
 
 # omp
 if (USE_OPENMP)
@@ -81,6 +77,8 @@ if (CMAKE_VERSION VERSION_LESS 3.1 OR NOT USE_COMPILE_FEATURES)
     set (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
   endif ()
 endif ()
+
+set (CMAKE_CXX_FLAGS "-O3 -g -mavx -mfma ${CMAKE_CXX_FLAGS}")
 
 if (BUILD_PYTHON)
   find_package (PythonInterp)

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -27,7 +27,7 @@ endif
 endif
 
 AM_CPPFLAGS=-I$(top_srcdir)/src/ -I$(EIGEN3_INC) $(GFLAGS_CFLAGS)
-AM_CXXFLAGS=-g -Wall
+AM_CXXFLAGS=-Wall -Wextra -g -O3 -mavx -mfma
 if !HAVE_CLANG
 AM_CXXFLAGS+=-fopenmp
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,7 @@ nobase_libcmaesinclude_HEADERS += surrcmaes.h surrogatestrategy.h surrogates/ran
 endif
 
 AM_CPPFLAGS=-I$(EIGEN3_INC)
-AM_CXXFLAGS=-Wall -Wextra -g
+AM_CXXFLAGS=-Wall -Wextra -g -O3 -mavx -mfma
 if !HAVE_CLANG
 AM_CXXFLAGS += -fopenmp
 endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,7 +14,7 @@ edm_SOURCES=edm.cc
 if HAVE_BBOB
 libbbobdir = $(libdir)
 libbbob_LIBRARIES=libbbob.a
-libbbob_a_SOURCES= bbob.v13.09/c/benchmarksdeclare.c bbob.v13.09/c/benchmarkshelper.c bbob.v13.09/c/benchmarks.c bbob.v13.09/c/benchmarksnoisy.c bbob.v13.09/c/fgeneric.c bbob.v13.09/c/dirOK.c 
+libbbob_a_SOURCES= bbob.v13.09/c/benchmarksdeclare.c bbob.v13.09/c/benchmarkshelper.c bbob.v13.09/c/benchmarks.c bbob.v13.09/c/benchmarksnoisy.c bbob.v13.09/c/fgeneric.c bbob.v13.09/c/dirOK.c
 bin_PROGRAMS += bbobexperiment
 bbobexperiment_SOURCES=bbobexperiment.cc
 endif
@@ -28,7 +28,7 @@ ut_scaling_SOURCES=ut-scaling.cc
 endif
 
 AM_CPPFLAGS=-I$(top_srcdir)/src/ -I$(EIGEN3_INC) $(GFLAGS_CFLAGS)
-AM_CXXFLAGS=-g -Wall
+AM_CXXFLAGS=-Wall -Wextra -g -O3 -mavx -mfma
 if !HAVE_CLANG
 AM_CXXFLAGS += -fopenmp
 endif


### PR DESCRIPTION
Hello,

First of all, thanks for this great library! We are using your library as one of our main optimization algorithms in our Gaussian Process/Bayesian Optimization **Limbo** library (check [here](http://www.resibots.eu/limbo/)). We are very much concerned by performance and as such we are switching to the newest Eigen (3.3) and we want to activate all the nice new features (see [this website](http://eigen.tuxfamily.org/index.php?title=3.3)). In particular, we are interested in the *Vectorization* enhancements using specific cpu instructions (avx, fma) and in replacing Eigen's algorithms with LAPACKE's (see [here](https://eigen.tuxfamily.org/dox/TopicUsingBlasLapack.html)) when it is necessary (i.e., big matrices).

Long story short, your library compiled with other flags than what we compile ours, produces some weird artifacts (eigen vector misalignments, seg faults etc.). This PR intends to change the compilation flags of your library. As far as I checked it doesn't break any other part of the library.

Let me know what you think!

*I also changed a small thing in the `CMakeLists.txt` that was not working for my setup.*

Best,
Konstantinos
