### PR TITLE
update cmake files for conda build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ option (USE_OPENMP "Use OpenMP for multithreading" ON)
 option (ENABLE_SURROG "support for surrogates" ON)
 set (HAVE_SURROG ${ENABLE_SURROG})
 option (USE_COMPILE_FEATURES "use cmake>=3.1 cxx11 detection" ON)
-option (LINK_PYTHON "link python libraries" ON)
 
 # Offer the user the choice of overriding the installation directories
 set (INSTALL_LIB_DIR     lib${LIB_SUFFIX} CACHE PATH "Installation directory for libraries")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -6,10 +6,15 @@ include_directories (${NUMPY_INCLUDE_DIRS})
 include_directories (${Boost_INCLUDE_DIRS})
 
 python_add_module (lcmaes lcmaes.cc)
+
 target_link_libraries(lcmaes cmaes ${Boost_LIBRARIES})
-if (LINK_PYTHON)
+
+if (WIN32)
   target_link_libraries(lcmaes ${PYTHON_LIBRARIES})
+elseif (APPLE)
+  set_target_properties(lcmaes PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 endif ()
+
 
 install (TARGETS lcmaes DESTINATION ${PYTHON_SITE_PACKAGES})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ macro (cmaes_add_test name)
   target_link_libraries (t_${name} cmaes)
   add_test (NAME ${name} COMMAND t_${name})
   if (WIN32)
-    set_tests_properties (${name} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\src\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
+    set_tests_properties (${name} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\src\\${CMAKE_BUILD_TYPE};${PROJECT_BINARY_DIR}\\src;$ENV{PATH}")  # to load dll
   endif ()
 endmacro ()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ macro (cmaes_add_test name)
   target_link_libraries (t_${name} cmaes)
   add_test (NAME ${name} COMMAND t_${name})
   if (WIN32)
-    set_tests_properties (${name} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\src\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
+    set_tests_properties (${name} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\src;${PROJECT_BINARY_DIR}\\src\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
   endif ()
 endmacro ()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ macro (cmaes_add_test name)
   target_link_libraries (t_${name} cmaes)
   add_test (NAME ${name} COMMAND t_${name})
   if (WIN32)
-    set_tests_properties (${name} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\src;${PROJECT_BINARY_DIR}\\src\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
+    set_tests_properties (${name} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\src\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
   endif ()
 endmacro ()
 


### PR DESCRIPTION
Hi @beniz,

in order to make the code build on conda, we had to patch up the CMake configuration a bit.

Whether the python libraries have to be linked depends on the operating system:
- On Windows, they need to be linked
- On MacOS, the Python module needs to be linked with `-undefined dynamic_lookup`
- On Linux, they don't need to be linked

This PR takes care of this logic so that we don't need the `LINK_PYTHON` option any longer.

Furthermore, the CMake build location for the library is `${PROJECT_BINARY_DIR}\\src` by default on Windows, which is added to the PATH for the C tests.

Tagging @jschueller 

Best,
Andreas