### PR TITLE
escape backslashes in PATH

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ macro (cmaes_add_test name)
   target_link_libraries (t_${name} cmaes)
   add_test (NAME ${name} COMMAND t_${name})
   if (WIN32)
-    set_tests_properties (${name} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\src\\${CMAKE_BUILD_TYPE};${PROJECT_BINARY_DIR}\\src;$ENV{PATH}")  # to load dll
+    set_tests_properties (${name} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\src\\${CMAKE_BUILD_TYPE}\;${PROJECT_BINARY_DIR}\\src\;$ENV{PATH}")  # to load dll
   endif ()
 endmacro ()
 


### PR DESCRIPTION
This is a tiny change in one of the CMake Files, which seems to fix the [conda-forge build](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=167264&view=logs&j=171a126d-c574-5c8c-1269-ff3b989e923d&t=1183ba29-a0b5-5324-8463-2a49ace9e213).
I want to see if it passes on your CI as well.
If it does, I would vote for putting out a new release that includes this fix.

This will make deployment easier in the future.