### PR TITLE
Add Numpy include directory to CPPFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,8 +133,8 @@ fi
 # Check for numpy
 if test x"$python" = x"true"; then
 AC_MSG_CHECKING([for Numpy include directory])
-CPPFLAGS="$PYTHON_CPPFLAGS $CPPFLAGS"
 NUMPY_INCLUDE_DIR=`echo "import numpy; print(numpy.get_include())" | $PYTHON - 2>/dev/null`
+CPPFLAGS="$PYTHON_CPPFLAGS -I${NUMPY_INCLUDE_DIR} $CPPFLAGS"
 AC_SUBST(NUMPY_INCLUDE_DIR)
 AC_CHECK_HEADER([${NUMPY_INCLUDE_DIR}/numpy/arrayobject.h],
                 [NUMPY_HEADER=yes],


### PR DESCRIPTION
Fix numpy 2.x build failure caused by `NUMPY_INCLUDE_DIR` not being added to `CPPFLAGS `before the `AC_CHECK_HEADER` test in `configure.ac`. Without this, the compiler cannot find the numpy headers even when they are present on the system.